### PR TITLE
Fix various errors in examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,14 +403,16 @@
 //!
 //! ``` ignore
 //! extern crate embedded_hal as hal;
+//! #[macro_use]
+//! extern crate nb;
 //!
 //! use hal::prelude::*;
 //!
 //! fn write_all<S>(serial: &S, buffer: &[u8]) -> Result<(), S::Error>
 //! where
-//!     S: hal::Serial
+//!     S: hal::serial::Write<u8>
 //! {
-//!     for byte in buffer {
+//!     for &byte in buffer {
 //!         block!(serial.write(byte))?;
 //!     }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,9 +508,9 @@
 //!
 //! use hal::prelude::*;
 //!
-//! fn flush(serial: &S, cb: &mut CircularBuffer) -> Result<(), S::Error>
+//! fn flush<S>(serial: &S, cb: &mut CircularBuffer) -> Result<(), S::Error>
 //! where
-//!     S: hal::Serial,
+//!     S: hal::serial::Write<u8>,
 //! {
 //!     loop {
 //!         if let Some(byte) = cb.peek() {
@@ -532,12 +532,12 @@
 //!
 //! // NOTE private
 //! static BUFFER: Mutex<CircularBuffer> = ..;
-//! static SERIAL: Mutex<impl hal::Serial> = ..;
+//! static SERIAL: Mutex<impl hal::serial::Write<u8>> = ..;
 //!
 //! impl BufferedSerial {
-//!     pub fn write(&self, byte: u8) {
+//!     pub fn write(&self, bytes: &[u8]) {
 //!         let mut buffer = BUFFER.lock();
-//!         for byte in byte {
+//!         for byte in bytes {
 //!             buffer.push(*byte).unwrap();
 //!         }
 //!     }
@@ -545,10 +545,9 @@
 //!     pub fn write_all(&self, bytes: &[u8]) {
 //!         let mut buffer = BUFFER.lock();
 //!         for byte in bytes {
-//!             cb.push(*byte).unwrap();
+//!             buffer.push(*byte).unwrap();
 //!         }
 //!     }
-//!
 //! }
 //!
 //! fn interrupt_handler() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,16 +190,21 @@
 //! implementation:
 //!
 //! ``` ignore
+//! extern crate embedded_hal as hal;
+//! extern crate nb;
+//!
 //! /// A synchronized serial interface
 //! // NOTE This is a global singleton
-//! pub struct Serial1;
+//! pub struct Serial1(Mutex<..>);
 //!
 //! // NOTE private
 //! static USART1: Mutex<_> = Mutex::new(..);
 //!
-//! impl hal::Serial for Serial {
-//!     fn read(&self) -> Result<u8, nb::Error<Error>> {
-//!         hal::Serial::read(&Serial(USART1.lock()))
+//! impl hal::serial::Read<u8> for Serial1 {
+//!     type Error = !;
+//!
+//!     fn read(&self) -> Result<u8, nb::Error<Self::Error>> {
+//!         hal::serial::Read::read(&Serial1(USART1.lock()))
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,23 +424,24 @@
 //!
 //! ``` ignore
 //! extern crate embedded_hal as hal;
+//! extern crate nb;
 //!
 //! use hal::prelude::*;
 //!
 //! enum Error<E> {
 //!     /// Serial interface error
-//!     Serial(E)
+//!     Serial(E),
 //!     TimedOut,
 //! }
 //!
-//! fn read_with_timeout(
+//! fn read_with_timeout<S, T>(
 //!     serial: &S,
 //!     timer: &T,
-//!     timeout: T::Ticks,
+//!     timeout: T::Time,
 //! ) -> Result<u8, Error<S::Error>>
 //! where
 //!     T: hal::Timer,
-//!     S: hal::Serial,
+//!     S: hal::serial::Read<u8>,
 //! {
 //!     timer.pause();
 //!     timer.restart();
@@ -457,6 +458,12 @@
 //!         }
 //!
 //!         match timer.wait() {
+//!             Err(nb::Error::Other(e)) => {
+//!                 // The error type specified by `timer.wait()` is `!`, which
+//!                 // means no error can actually occur. The Rust compiler
+//!                 // still forces us to provide this match arm, though.
+//!                 e
+//!             },
 //!             Err(nb::Error::WouldBlock) => continue,
 //!             Ok(()) => {
 //!                 timer.pause();


### PR DESCRIPTION
I've been working on picking up the stalled #16. Since this PR includes a change request regarding an example, I wanted to make sure to properly test all of them, but found out that they're kind of a mess. There were a lot of build errors that a user copying them into a new project would face.

I fixed a lot of those errors, and left others in there. The commits have more details about that. I do think that this PR, while clearly an improvement, is just papering over the deeper issue: That the examples are ignored (as in, not compiled during `cargo test`), and therefore prone to break and become out of date. I think we should find a way to change that, but that is beyond the scope of this humble pull request.