### PR TITLE
Add `flush` method to `serial::Write`

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -26,4 +26,7 @@ pub trait Write<Word> {
 
     /// Writes a single word to the serial interface
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+
+    /// Ensures that none of the previously written words are still buffered
+    fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }


### PR DESCRIPTION
As suggested previously here: https://github.com/japaric/embedded-hal/issues/3#issuecomment-325887412