### PR TITLE
Added new (yet unproven) blocking Read trait for a rngs

### DIFF
--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -8,3 +8,4 @@ pub mod delay;
 pub mod i2c;
 pub mod serial;
 pub mod spi;
+pub mod rng;

--- a/src/blocking/rng.rs
+++ b/src/blocking/rng.rs
@@ -1,6 +1,7 @@
 //! Blocking hardware random number generator
 
 /// Blocking read
+#[cfg(feature = "unproven")]
 pub trait Read {
     /// Error type
     type Error;

--- a/src/blocking/rng.rs
+++ b/src/blocking/rng.rs
@@ -7,5 +7,11 @@ pub trait Read {
     type Error;
 
     /// Reads enough bytes from hardware random number generator to fill `buffer`
+    ///
+    /// If any error is encountered then this function immediately returns. The contents of buf are
+    /// unspecified in this case.
+    ///
+    /// If this function returns an error, it is unspecified how many bytes it has read, but it
+    /// will never read more than would be necessary to completely fill the buffer.
     fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error>;
 }

--- a/src/blocking/rng.rs
+++ b/src/blocking/rng.rs
@@ -1,0 +1,10 @@
+//! Blocking hardware random number generator
+
+/// Blocking read
+pub trait Read {
+    /// Error type
+    type Error;
+
+    /// Reads enough bytes from hardware random number generator to fill `buffer`
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error>;
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,6 +23,8 @@ pub use ::blocking::spi::{
     Transfer as _embedded_hal_blocking_spi_Transfer,
     Write as _embedded_hal_blocking_spi_Write,
 };
+#[cfg(feature = "unproven")]
+pub use ::blocking::rng::Read as _embedded_hal_blocking_rng_Read;
 pub use ::digital::OutputPin as _embedded_hal_digital_OutputPin;
 #[cfg(feature = "unproven")]
 pub use ::digital::InputPin as _embedded_hal_digital_InputPin;


### PR DESCRIPTION
Implements #38 . Identical custom trait already implemented in `nrf51-hal` crate and used in 
examples (directly and to seed a PRNG) in the `microbit` crate.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>