### PR TITLE
[RFC] add iterator based blocking `Write` traits

### DIFF
--- a/src/blocking/i2c.rs
+++ b/src/blocking/i2c.rs
@@ -50,6 +50,22 @@ pub trait Write {
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error>;
 }
 
+/// Blocking write (iterator version)
+#[cfg(feature = "unproven")]
+pub trait WriteIter {
+    /// Error type
+    type Error;
+
+    /// Sends bytes to slave with address `addr`
+    ///
+    /// # I2C Events (contract)
+    ///
+    /// Same as `Write`
+    fn write<B>(&mut self, addr: u8, bytes: B) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>;
+}
+
 /// Blocking write + read
 pub trait WriteRead {
     /// Error type
@@ -83,4 +99,26 @@ pub trait WriteRead {
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Self::Error>;
+}
+
+/// Blocking write (iterator version) + read
+#[cfg(feature = "unproven")]
+pub trait WriteIterRead {
+    /// Error type
+    type Error;
+
+    /// Sends bytes to slave with address `addr` and then reads enough bytes to fill `buffer` *in a
+    /// single transaction*
+    ///
+    /// # I2C Events (contract)
+    ///
+    /// Same as the `WriteRead` trait
+    fn write_iter_read<B>(
+        &mut self,
+        address: u8,
+        bytes: B,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error>
+        where
+        B: IntoIterator<Item = u8>;
 }

--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -76,3 +76,31 @@ pub mod write {
         }
     }
 }
+
+/// Blocking write (iterator version)
+#[cfg(feature = "unproven")]
+pub mod write_iter {
+    /// Default implementation of `blocking::spi::WriteIter<W>` for implementers of
+    /// `spi::FullDuplex<W>`
+    pub trait Default<W>: ::spi::FullDuplex<W> {}
+
+    impl<W, S> ::blocking::spi::WriteIter<W> for S
+    where
+        S: Default<W>,
+        W: Clone,
+    {
+        type Error = S::Error;
+
+        fn write_iter<WI>(&mut self, words: WI) -> Result<(), S::Error>
+        where
+            WI: IntoIterator<Item = W>,
+        {
+            for word in words.into_iter() {
+                block!(self.send(word.clone()))?;
+                block!(self.read())?;
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -18,6 +18,18 @@ pub trait Write<W> {
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
 }
 
+/// Blocking write (iterator version)
+#[cfg(feature = "unproven")]
+pub trait WriteIter<W> {
+    /// Error type
+    type Error;
+
+    /// Sends `words` to the slave, ignoring all the incoming words
+    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = W>;
+}
+
 /// Blocking transfer
 pub mod transfer {
     /// Default implementation of `blocking::spi::Transfer<W>` for implementers of


### PR DESCRIPTION
## Motivation

Some use cases require sending to a I2C / SPI slave some header (e.g. `u16`) followed by a data
buffer (`&[u8]`).

With the current API, which only works with slices (`&[u8]`), this requires the user to copy both
the header and the original buffer in a slightly larger buffer and then send that buffer to the
slave. This approach may result in a large memcpy (between stack allocated buffers) at runtime. It
also requires the caller to allocate a temporary buffer large enough which can sometimes be
impossible (size of data buffer is only known at runtime) or wasteful (allocate a buffer that fits
both the header and the largest possible size of the data buffer).

A more appropriate API for this use case is one that accepts iterators as arguments. Then the user
can write something like this:

``` rust
use core::iter;

let header: u8 = 0xAB;
let data_buffer: &[u8] = ..;

spi.write_iter(iter::once(header).chain(data_buffer))?;
```

Instead of something like this:

``` rust
let header: u8 = 0xAB;
let data_buffer: &[u8] = ..;

// is this large enough? is it too large?
let mut temp_buffer: [u8; 128] = [0; 128];
temp_buffer[0] = header;
// this will panic if the buffer is not large enough
temp_buffer[1..data_buffer.len() + 1].copy_from_slice(&data_buffer);

spi.write(&temp_buffer)?;
```

## Detailed design

This RFC proposes adding one iterator-based trait for each `*Write*` trait in the
`blocking::{i2c,spi}` modules. The API of these traits is similar to their slice counterparts except
that they take a generic `impl IntoIterator<Item = W>` argument instead of an slice (`&[W]`).

For the full signature of the traits check the contents of the PR.

## Drawbacks

`i2cdev` and `spidev` would have to implement these using dynamic memory allocation as their APIs
only work with slices.

``` rust
impl spi::WriteIter<u8> for Spidev {
    type Error = Error;

    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
    where
        WI: IntoIterator<Item = W>
    {
        let v: Vec<u8> = words.into_iter().collect();
        // defer to spi::Write
        self.write(&v)
    }
}
```

But Linux devices are not as resource constrained as microcontroller so this is probably not a
problem.

## Alternatives

Add `write_iter` as another method of `Write`. This is totally doable but it would be a breaking
change because there's no way to provide a default implementation of `write_iter` based on `write`
(at least without allocating).

## Unresolved questions

- Bikeshed the names of the traits / methods.

- Should we add a `WriteIter` counterpart to `blocking::serial::Write`? cc @hannobraun 

cc @wose @jamesmunns 