### PR TITLE
Enable cancelable countdowns via a new `Cancel` trait

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -77,3 +77,17 @@ pub trait CountDown {
 
 /// Marker trait that indicates that a timer is periodic
 pub trait Periodic {}
+
+/// Trait for cancelable countdowns.
+pub trait Cancel : CountDown {
+    /// Error returned when a countdown can't be canceled.
+    type Error;
+
+    /// Tries to cancel this countdown.
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned if the countdown has already been canceled or was never started.
+    /// An error is also returned if the countdown is not `Periodic` and has already expired.
+    fn cancel(&mut self) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
Fixes #65

~~This is the simplest solution; it breaks every current `CountDown` implementor. Not sure what the policy around breaking changes is since there haven't been any yet.~~

This now adds a `Cancel` trait that can be implemented by timers to make it possible to cancel a running countdown.

(this is no longer a breaking change)