### PR TITLE
replace uses of ! with Void

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,8 @@ before_cache:
 
 branches:
   only:
-    - auto
-    - master
-    - try
+    - staging
+    - trying
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: rust
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
+
+    - env: TARGET=thumbv6m-none-eabi
+      rust: beta
+
+    - env: TARGET=thumbv7m-none-eabi
+      rust: beta
+
+    - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
 
 before_install: set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.0] - 2018-05-11
+
+### Changed
+
+- [breaking-change] The signature of `CountDown.wait` changed; it now returns `nb::Result<(),
+  Void>`. Where [`Void`] is the stable alternative to the never type, `!`, provided by the stable
+  [`void`] crate. Implementations of the `CountDown` trait will have to be updated to use the new
+  signature. With this change this crate compiles on the stable and beta channels.
+
+[`Void`]: https://docs.rs/void/1.0.2/void/enum.Void.html
+[`void`]: https://crates.io/crates/void
+
 ## [v0.1.2] - 2018-02-14
 
 ### Added
@@ -23,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/embedded-hal/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/japaric/embedded-hal/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/japaric/embedded-hal/compare/v0.1.2...v0.2.0
 [v0.1.2]: https://github.com/japaric/embedded-hal/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/japaric/embedded-hal/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 repository = "https://github.com/japaric/embedded-hal"
 version = "0.1.2"
 
+[dependencies.void]
+default-features = false
+version = "1.0.2"
+
 [dependencies.nb]
 version = "0.1.1"
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,7 +1,9 @@
 set -euxo pipefail
 
 main() {
-    return
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        rustup target add $TARGET
+    fi
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,7 +2,11 @@ set -euxo pipefail
 
 main() {
     cargo check --target $TARGET
-    cargo test --target $TARGET --features unproven
+    cargo check --target $TARGET --features unproven
+
+    if [ $TRAVIS_RUST_VERSION = nightly ]; then
+        cargo test --target $TARGET --features unproven
+    fi
 }
 
 main

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,7 @@
 //! Timers
 
 use nb;
+use void::Void;
 
 /// A count down timer
 ///
@@ -17,7 +18,6 @@ use nb;
 /// You can use this timer to create delays
 ///
 /// ```
-/// # #![feature(never_type)]
 /// extern crate embedded_hal as hal;
 /// #[macro_use(block)]
 /// extern crate nb;
@@ -40,6 +40,8 @@ use nb;
 ///     Led.off();
 /// }
 ///
+/// # extern crate void;
+/// # use void::Void;
 /// # struct Seconds(u32);
 /// # trait U32Ext { fn s(self) -> Seconds; }
 /// # impl U32Ext for u32 { fn s(self) -> Seconds { Seconds(self) } }
@@ -52,7 +54,7 @@ use nb;
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Time = Seconds;
 /// #     fn start<T>(&mut self, _: T) where T: Into<Seconds> {}
-/// #     fn wait(&mut self) -> ::nb::Result<(), !> { Ok(()) }
+/// #     fn wait(&mut self) -> ::nb::Result<(), Void> { Ok(()) }
 /// # }
 /// ```
 pub trait CountDown {
@@ -72,7 +74,7 @@ pub trait CountDown {
     /// finishes.
     /// - Otherwise the behavior of calling `wait` after the last call returned `Ok` is UNSPECIFIED.
     /// Implementers are suggested to panic on this scenario to signal a programmer error.
-    fn wait(&mut self) -> nb::Result<(), !>;
+    fn wait(&mut self) -> nb::Result<(), Void>;
 }
 
 /// Marker trait that indicates that a timer is periodic


### PR DESCRIPTION
We are soon going to push for embedded *library* development on beta (1.27-beta) to minimize the
number of unstable features used in the ecosystem and ease the transition towards *application*
development on stable (1.28 or 1.29).

Unfortunately `!` didn't make it into the beta release but we still need to make this crate work on
beta because a lot of crates depend on it. So this PR replaces the single use of the `!` type (cf.
`CountDown.wait`) with the equivalent, but stable, `Void` type.

This is a [breaking-change]. Implementations of the `CountDown` trait will have to update the
signature of `wait` to return `nb::Result<(), Void>`.

cc @therealprof @hannobraun I'm going to publish v0.2.0 *soon* (ideally tonight). If there's
some **breaking**, but *uncontroversial*, change that should be included in it let me know ASAP so
we can land it before the release.